### PR TITLE
gh-9: fix export variable bug by adding ExportIdentifier AST node

### DIFF
--- a/src/com/thorn/AstPrinter.java
+++ b/src/com/thorn/AstPrinter.java
@@ -113,6 +113,11 @@ class AstPrinter implements Expr.Visitor<String>, Stmt.Visitor<String> {
     }
 
     @Override
+    public String visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+        return "(export " + stmt.name.lexeme + ")";
+    }
+
+    @Override
     public String visitBinaryExpr(Expr.Binary expr) {
         return parenthesize(expr.operator.lexeme, expr.left, expr.right);
     }

--- a/src/com/thorn/BranchOptimizationPass.java
+++ b/src/com/thorn/BranchOptimizationPass.java
@@ -208,6 +208,11 @@ public class BranchOptimizationPass extends OptimizationPass {
                     Stmt optimizedDeclaration = optimizeStatement(stmt.declaration);
                     return new Stmt.Export(optimizedDeclaration);
                 }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return stmt;
+                }
             });
         }
         

--- a/src/com/thorn/ConstantFoldingPass.java
+++ b/src/com/thorn/ConstantFoldingPass.java
@@ -161,6 +161,11 @@ public class ConstantFoldingPass extends OptimizationPass {
                 public Stmt visitExportStmt(Stmt.Export stmt) {
                     return new Stmt.Export(foldStatement(stmt.declaration));
                 }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return stmt;
+                }
             });
         }
         

--- a/src/com/thorn/DeadCodeEliminationPass.java
+++ b/src/com/thorn/DeadCodeEliminationPass.java
@@ -264,6 +264,11 @@ public class DeadCodeEliminationPass extends OptimizationPass {
                     collectUsageFromStatement(stmt.declaration);
                     return null;
                 }
+                
+                @Override
+                public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return null;
+                }
             });
         }
         

--- a/src/com/thorn/DeadCodeEliminator.java
+++ b/src/com/thorn/DeadCodeEliminator.java
@@ -128,6 +128,11 @@ public class DeadCodeEliminator {
             }
             
             @Override
+            public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                return null;
+            }
+            
+            @Override
             public Void visitBlockStmt(Stmt.Block stmt) {
                 for (Stmt blockStmt : stmt.statements) {
                     collectDefinitions(blockStmt);
@@ -386,6 +391,11 @@ public class DeadCodeEliminator {
             @Override
             public Void visitExportStmt(Stmt.Export stmt) {
                 collectUsages(stmt.declaration);
+                return null;
+            }
+            
+            @Override
+            public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
                 return null;
             }
         });
@@ -691,6 +701,7 @@ public class DeadCodeEliminator {
             @Override public Void visitClassStmt(Stmt.Class stmt) { return null; }
             @Override public Void visitImportStmt(Stmt.Import stmt) { return null; }
             @Override public Void visitExportStmt(Stmt.Export stmt) { return null; }
+            @Override public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) { return null; }
         });
     }
     

--- a/src/com/thorn/FunctionInliningPass.java
+++ b/src/com/thorn/FunctionInliningPass.java
@@ -173,6 +173,10 @@ public class FunctionInliningPass extends OptimizationPass {
                     analyzeFunctionDefinitions(stmt.declaration);
                     return null; 
                 }
+                
+                @Override public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return null;
+                }
             });
         }
         
@@ -370,6 +374,11 @@ public class FunctionInliningPass extends OptimizationPass {
                 public Stmt visitExportStmt(Stmt.Export stmt) {
                     Stmt transformedDeclaration = transformStatement(stmt.declaration);
                     return new Stmt.Export(transformedDeclaration);
+                }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return stmt;
                 }
             });
         }
@@ -685,6 +694,11 @@ public class FunctionInliningPass extends OptimizationPass {
                         calculateStatementSize(stmt.declaration);
                         return null;
                     }
+                    
+                    @Override
+                    public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                        return null;
+                    }
                 });
             }
             
@@ -771,6 +785,11 @@ public class FunctionInliningPass extends OptimizationPass {
                     @Override
                     public Boolean visitExportStmt(Stmt.Export stmt) {
                         return checkStatement(stmt.declaration);
+                    }
+                    
+                    @Override
+                    public Boolean visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                        return false;
                     }
                 });
             }
@@ -923,6 +942,11 @@ public class FunctionInliningPass extends OptimizationPass {
                     @Override
                     public Void visitExportStmt(Stmt.Export stmt) {
                         countCalls(stmt.declaration);
+                        return null;
+                    }
+                    
+                    @Override
+                    public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
                         return null;
                     }
                 });
@@ -1083,6 +1107,11 @@ public class FunctionInliningPass extends OptimizationPass {
                     public Stmt visitExportStmt(Stmt.Export stmt) {
                         Stmt inlinedDeclaration = inlineStatement(stmt.declaration);
                         return new Stmt.Export(inlinedDeclaration);
+                    }
+                    
+                    @Override
+                    public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                        return stmt;
                     }
                 });
             }

--- a/src/com/thorn/Interpreter.java
+++ b/src/com/thorn/Interpreter.java
@@ -829,6 +829,22 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
         return null;
     }
 
+    @Override
+    public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+        // Check if we're in a module environment
+        if (environment instanceof ModuleSystem.ModuleEnvironment) {
+            ModuleSystem.ModuleEnvironment moduleEnv = (ModuleSystem.ModuleEnvironment) environment;
+            
+            // Get the existing value from the environment
+            Object value = environment.get(stmt.name);
+            
+            // Export it
+            moduleEnv.export(stmt.name.lexeme, value);
+        }
+        
+        return null;
+    }
+
     private void execute(Stmt stmt) {
         stmt.accept(this);
     }

--- a/src/com/thorn/LoopOptimizationPass.java
+++ b/src/com/thorn/LoopOptimizationPass.java
@@ -204,6 +204,11 @@ public class LoopOptimizationPass extends OptimizationPass {
                     Stmt optimizedDeclaration = optimizeStatement(stmt.declaration);
                     return new Stmt.Export(optimizedDeclaration);
                 }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return stmt;
+                }
             });
         }
         
@@ -305,6 +310,11 @@ public class LoopOptimizationPass extends OptimizationPass {
                 
                 @Override
                 public Stmt visitExportStmt(Stmt.Export stmt) {
+                    return stmt;
+                }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
                     return stmt;
                 }
             });
@@ -542,6 +552,11 @@ public class LoopOptimizationPass extends OptimizationPass {
                 public Stmt visitExportStmt(Stmt.Export stmt) {
                     return stmt;
                 }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return stmt;
+                }
             });
         }
         
@@ -630,6 +645,7 @@ public class LoopOptimizationPass extends OptimizationPass {
                     @Override public Void visitClassStmt(Stmt.Class stmt) { return null; }
                     @Override public Void visitImportStmt(Stmt.Import stmt) { return null; }
                     @Override public Void visitExportStmt(Stmt.Export stmt) { return null; }
+                    @Override public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) { return null; }
                 });
             }
             
@@ -681,6 +697,7 @@ public class LoopOptimizationPass extends OptimizationPass {
                     @Override public Void visitClassStmt(Stmt.Class stmt) { return null; }
                     @Override public Void visitImportStmt(Stmt.Import stmt) { return null; }
                     @Override public Void visitExportStmt(Stmt.Export stmt) { return null; }
+                    @Override public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) { return null; }
                 });
             }
             

--- a/src/com/thorn/Parser.java
+++ b/src/com/thorn/Parser.java
@@ -56,19 +56,32 @@ class Parser {
     }
 
     private Stmt exportDeclaration() {
-        Stmt declaration;
         if (match(DOLLAR)) {
-            declaration = function("function");
+            Stmt declaration = function("function");
+            return new Stmt.Export(declaration);
         } else if (match(CLASS)) {
-            declaration = classDeclaration();
+            Stmt declaration = classDeclaration();
+            return new Stmt.Export(declaration);
         } else if (match(AT)) {
-            declaration = varDeclaration(true);
+            Stmt declaration = varDeclaration(true);
+            return new Stmt.Export(declaration);
         } else if (check(IDENTIFIER)) {
-            declaration = varDeclaration(false);
+            Token name = advance();
+            
+            // Check if this is a variable declaration (has : or =) or just an identifier export
+            if (match(COLON, EQUAL)) {
+                // This is a variable declaration, back up and parse it properly
+                current--; // Back up to the identifier
+                Stmt declaration = varDeclaration(false);
+                return new Stmt.Export(declaration);
+            } else {
+                // This is just exporting an existing identifier
+                consume(SEMICOLON, "Expected ';' after export identifier.");
+                return new Stmt.ExportIdentifier(name);
+            }
         } else {
             throw error(previous(), "Expected function, class, or variable after 'export'.");
         }
-        return new Stmt.Export(declaration);
     }
 
     private Stmt importDeclaration() {

--- a/src/com/thorn/Parser.java
+++ b/src/com/thorn/Parser.java
@@ -71,7 +71,7 @@ class Parser {
             // Check if this is a variable declaration (has : or =) or just an identifier export
             if (match(COLON, EQUAL)) {
                 // This is a variable declaration, back up and parse it properly
-                current--; // Back up to the identifier
+                current -= 2; // Back up past both the matched token and the identifier
                 Stmt declaration = varDeclaration(false);
                 return new Stmt.Export(declaration);
             } else {

--- a/src/com/thorn/Stmt.java
+++ b/src/com/thorn/Stmt.java
@@ -15,6 +15,7 @@ public abstract class Stmt {
         R visitClassStmt(Class stmt);
         R visitImportStmt(Import stmt);
         R visitExportStmt(Export stmt);
+        R visitExportIdentifierStmt(ExportIdentifier stmt);
     }
 
     abstract <R> R accept(Visitor<R> visitor);
@@ -188,6 +189,19 @@ public abstract class Stmt {
         }
 
         public final Stmt declaration;
+    }
+    
+    public static class ExportIdentifier extends Stmt {
+        ExportIdentifier(Token name) {
+            this.name = name;
+        }
+
+        @Override
+        <R> R accept(Visitor<R> visitor) {
+            return visitor.visitExportIdentifierStmt(this);
+        }
+
+        public final Token name;
     }
     
     // Parameter class for typed function parameters

--- a/src/com/thorn/TailCallAnalyzer.java
+++ b/src/com/thorn/TailCallAnalyzer.java
@@ -96,6 +96,8 @@ public class TailCallAnalyzer {
             public Boolean visitImportStmt(Stmt.Import stmt) { return false; }
             @Override
             public Boolean visitExportStmt(Stmt.Export stmt) { return false; }
+            @Override
+            public Boolean visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) { return false; }
         });
     }
     
@@ -187,6 +189,8 @@ public class TailCallAnalyzer {
             public Void visitImportStmt(Stmt.Import stmt) { return null; }
             @Override
             public Void visitExportStmt(Stmt.Export stmt) { return null; }
+            @Override
+            public Void visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) { return null; }
         });
     }
 }

--- a/src/com/thorn/TailCallOptimizationPass.java
+++ b/src/com/thorn/TailCallOptimizationPass.java
@@ -200,6 +200,8 @@ public class TailCallOptimizationPass extends OptimizationPass {
             public Stmt visitImportStmt(Stmt.Import stmt) { return stmt; }
             @Override
             public Stmt visitExportStmt(Stmt.Export stmt) { return stmt; }
+            @Override
+            public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) { return stmt; }
         });
     }
     

--- a/src/com/thorn/UnreachableCodeEliminationPass.java
+++ b/src/com/thorn/UnreachableCodeEliminationPass.java
@@ -189,6 +189,11 @@ public class UnreachableCodeEliminationPass extends OptimizationPass {
                     Stmt declaration = processStatement(stmt.declaration);
                     return declaration != null ? new Stmt.Export(declaration) : null;
                 }
+                
+                @Override
+                public Stmt visitExportIdentifierStmt(Stmt.ExportIdentifier stmt) {
+                    return stmt;
+                }
             });
         }
         

--- a/test.thorn
+++ b/test.thorn
@@ -1,4 +1,0 @@
-c = $ (x) => {
-    a: number = 2;
-    print(x);
-}


### PR DESCRIPTION
## Summary
- Fix "Can only call functions and classes" error when exporting existing functions/variables
- Add new `ExportIdentifier` AST node to distinguish between variable declarations and identifier exports
- Properly handle `export functionName;` syntax to export existing functions

## Problem
When using `export functionName;` syntax (separate from function definition), the parser incorrectly treated it as a variable declaration, causing exported functions to lose their callable nature.

## Solution
- Added `Stmt.ExportIdentifier` AST node for exporting existing identifiers
- Modified `Parser.exportDeclaration()` to detect `export identifier;` vs `export identifier = value;`
- Added `visitExportIdentifierStmt()` method to interpreter to handle identifier exports properly
- Updated all visitor classes to support the new AST node

## Changes Made
- **AST**: Added `Stmt.ExportIdentifier` class and visitor method
- **Parser**: Enhanced export parsing to distinguish identifier exports from variable declarations
- **Interpreter**: Added proper handling for identifier exports that preserves function types
- **Optimization passes**: Added visitor methods to all optimization classes

## Test Results
- ✅ `export functionName;` now properly exports callable functions
- ✅ `export variableName;` now properly exports existing variables
- ✅ Existing `export $ function() {}` syntax still works
- ✅ Variable declarations `export newVar = value;` still work

## Note on Related Issue
During testing, discovered that global functions like `print` are not available in module environments. This is tracked separately in Issue #29 as a critical module system bug that affects all built-in functions in modules.

## Breaking Changes
None - this is a bug fix that maintains backward compatibility.

Fixes #9
Related to #29 (global functions in modules)