### PR TITLE
gh-29: fix global functions not available in module environments

### DIFF
--- a/src/com/thorn/ModuleSystem.java
+++ b/src/com/thorn/ModuleSystem.java
@@ -105,7 +105,7 @@ public class ModuleSystem {
             loadedModules.put(modulePath, module);
             
             // Execute the module in its own environment with export tracking
-            ModuleEnvironment moduleEnv = new ModuleEnvironment(module);
+            ModuleEnvironment moduleEnv = new ModuleEnvironment(module, interpreter.globals);
             interpreter.executeModule(statements, moduleEnv);
             
             return module;
@@ -153,7 +153,8 @@ public class ModuleSystem {
     public static class ModuleEnvironment extends Environment {
         private final Module module;
         
-        public ModuleEnvironment(Module module) {
+        public ModuleEnvironment(Module module, Environment globals) {
+            super(globals);
             this.module = module;
         }
         


### PR DESCRIPTION
## Summary
- Fix critical bug where modules couldn't access global built-in functions like `print()` and `clock()`
- ModuleEnvironment now properly inherits from the global environment
- Resolves module system being largely unusable for real-world applications

## Problem
Modules were created with isolated environments that had no access to the global environment containing built-in functions. This caused:
- `Undefined variable 'print'` errors in modules
- `Undefined variable 'clock'` errors in modules
- Made module system unusable for basic logging, debugging, and timing

## Root Cause
The `ModuleEnvironment` constructor was calling `Environment()` with no parent, setting `enclosing = null` and cutting off access to globals.

## Solution
1. **Modified `ModuleEnvironment` constructor** to accept `globals` parameter
2. **Updated inheritance** to call `super(globals)` to set proper parent environment
3. **Updated call site** in `ModuleSystem.loadModule()` to pass `interpreter.globals`

## Code Changes
```java
// Before
public ModuleEnvironment(Module module) {
    // Called Environment() with enclosing = null
    this.module = module;
}

// After  
public ModuleEnvironment(Module module, Environment globals) {
    super(globals);  // Now inherits from globals
    this.module = module;
}
```

## Test Results
- ✅ Modules can now use `print()` for output and debugging
- ✅ Modules can now use `clock()` for timing and benchmarking
- ✅ Module-level code can access globals during initialization
- ✅ Exported functions can use globals when called
- ✅ Both interpreter and VM modes work correctly
- ✅ Main environment functionality unchanged
- ✅ Module isolation preserved - modules still have their own scope

## Impact
This fix makes the module system fully functional for real-world development:
- Enables proper logging and debugging in modules
- Allows timing and performance measurement in modules
- Unblocks module-based architecture patterns
- Essential for any module that needs basic I/O or utilities

## Breaking Changes
None - this is a bug fix that enables expected functionality.

## Testing
Comprehensive testing confirms:
- All built-in functions work in modules
- No regressions in main environment
- Module exports work correctly
- Both execution modes supported

Fixes #29 (critical priority)