### PR TITLE
gh-15: fix object literal syntax not working in method calls and function arguments

### DIFF
--- a/examples/lambdas/large_event_system.thorn
+++ b/examples/lambdas/large_event_system.thorn
@@ -1,19 +1,8 @@
 // Let's build an event system to understand how lambdas enable powerful patterns!
 // You'll learn how lambdas can be stored, passed around, and called later.
 
-// Simple data classes for our events (workaround until object literals are fixed)
-class GameStartData {
-    $ init(time: string) {
-        this.time = time;
-    }
-}
-
-class PlayerScoreData {
-    $ init(player: string, points: number) {
-        this.player = player;
-        this.points = points;
-    }
-}
+// Note: Now using object literals directly instead of wrapper classes!
+// Object literals like {"key": "value"} are now fully supported.
 
 class EventData {
     $ init() {
@@ -202,28 +191,28 @@ game_events = EventEmitter();
 // Register multiple handlers for the same event
 // Each lambda will be called when "player_score" is emitted
 game_events.on("player_score", $(data) => {
-    print("Score updated! Player: " + data.player + ", Points: " + data.points);
+    print("Score updated! Player: " + data["player"] + ", Points: " + data["points"]);
 });
 
 // This lambda checks for high scores
 game_events.on("player_score", $(data) => {
-    if (data.points >= 100) {
-        print("🎉 " + data.player + " reached 100 points!");
+    if (data["points"] >= 100) {
+        print("🎉 " + data["player"] + " reached 100 points!");
     }
 });
 
 // This lambda only runs once, then removes itself
 game_events.once("game_start", $(data) => {
-    print("Game started at: " + data.time);
+    print("Game started at: " + data["time"]);
     print("(This message only appears once)\n");
 });
 
 // Trigger the events and watch our lambdas respond
-game_events.emit("game_start", GameStartData("10:00 AM"));
-game_events.emit("game_start", GameStartData("10:01 AM"));  // Won't print - handler removed itself
+game_events.emit("game_start", {"time": "10:00 AM"});
+game_events.emit("game_start", {"time": "10:01 AM"});  // Won't print - handler removed itself
 
-game_events.emit("player_score", PlayerScoreData("Alice", 50));
-game_events.emit("player_score", PlayerScoreData("Bob", 120));  // Triggers high score message
+game_events.emit("player_score", {"player": "Alice", "points": 50});
+game_events.emit("player_score", {"player": "Bob", "points": 120});  // Triggers high score message
 
 print("\n=== Observable Pattern Demo ===\n");
 

--- a/src/com/thorn/Parser.java
+++ b/src/com/thorn/Parser.java
@@ -636,10 +636,36 @@ class Parser {
 
     private boolean checkAhead(TokenType type) {
         int i = current;
+        int braceDepth = 0;
+        int parenDepth = 0;
+        int bracketDepth = 0;
+        
         while (i < tokens.size() - 1) {
             i++;
-            if (tokens.get(i).type == type) return true;
-            if (tokens.get(i).type == SEMICOLON) return false;
+            TokenType currentType = tokens.get(i).type;
+            
+            // Track nesting levels
+            if (currentType == LEFT_BRACE) braceDepth++;
+            else if (currentType == RIGHT_BRACE) braceDepth--;
+            else if (currentType == LEFT_PAREN) parenDepth++;
+            else if (currentType == RIGHT_PAREN) parenDepth--;
+            else if (currentType == LEFT_BRACKET) bracketDepth++;
+            else if (currentType == RIGHT_BRACKET) bracketDepth--;
+            
+            // Only consider colons at top level (not nested)
+            if (currentType == type && braceDepth == 0 && parenDepth == 0 && bracketDepth == 0) {
+                return true;
+            }
+            
+            // Stop at semicolon (end of statement)
+            if (currentType == SEMICOLON) return false;
+            
+            // Stop at expression boundaries that indicate this isn't a variable declaration
+            if (braceDepth == 0 && parenDepth == 0 && bracketDepth == 0) {
+                if (currentType == DOT || currentType == LEFT_PAREN || currentType == LEFT_BRACKET) {
+                    return false;
+                }
+            }
         }
         return false;
     }

--- a/tests/gh-15/README.md
+++ b/tests/gh-15/README.md
@@ -1,0 +1,33 @@
+# Tests for Issue #15
+
+
+
+
+## Test Files
+
+This directory contains test cases specific to Issue #15. These tests will:
+- Run automatically when the PR is opened/updated
+- Be cleaned up automatically when the PR is merged
+- Test both interpreter and VM modes
+
+## Adding Tests
+
+Create `.thorn` files in this directory. Each file should:
+- Be a complete, runnable Thorn program
+- Test a specific aspect of the fix
+- Have descriptive names (e.g., `basic_functionality.thorn`, `edge_cases.thorn`)
+
+## Test Categories
+
+Consider creating tests for:
+- ✅ Basic functionality
+- ✅ Edge cases  
+- ✅ Error conditions
+- ✅ Integration with other features
+- ✅ Both interpreter and VM modes
+
+## Notes
+
+- Tests run with a 30-second timeout
+- Failed tests will show error output in CI
+- Tests are automatically cleaned up after PR merge

--- a/tests/gh-15/event_system_example.thorn
+++ b/tests/gh-15/event_system_example.thorn
@@ -1,0 +1,32 @@
+// Test: Event system example from the original issue
+class EventEmitter {
+    $ init() {
+        this.listeners = {};
+    }
+    
+    $ on(event_name: string, handler: Function[void]): void {
+        if (this.listeners[event_name] == null) {
+            this.listeners[event_name] = [];
+        }
+        listeners_array = this.listeners[event_name];
+        listeners_array.push(handler);
+    }
+    
+    $ emit(event_name: string, data: Any): void {
+        listeners_array = this.listeners[event_name];
+        if (listeners_array != null) {
+            for (handler in listeners_array) {
+                handler(data);
+            }
+        }
+    }
+}
+
+game_events = EventEmitter();
+
+game_events.on("game_start", $(data) => {
+    print("Game started at: " + data["time"]);
+});
+
+game_events.emit("game_start", {"time": "10:00 AM"});
+game_events.emit("player_score", {"player": "Alice", "points": 150});

--- a/tests/gh-15/function_arg_object_literal.thorn
+++ b/tests/gh-15/function_arg_object_literal.thorn
@@ -1,0 +1,7 @@
+// Test: Function with object literal argument
+$ testFunction(config: Any): void {
+    print("Function called with config: " + config);
+}
+
+testFunction({"debug": true, "port": 8080});
+testFunction({"env": "production", "timeout": 30});

--- a/tests/gh-15/method_call_object_literal.thorn
+++ b/tests/gh-15/method_call_object_literal.thorn
@@ -1,0 +1,10 @@
+// Test: Method call with object literal argument
+class TestClass {
+    $ method(data: Any): void {
+        print("Method called with: " + data);
+    }
+}
+
+obj = TestClass();
+obj.method({"key": "value"});
+obj.method({"name": "Alice", "age": 25});

--- a/tests/gh-15/nested_object_literals.thorn
+++ b/tests/gh-15/nested_object_literals.thorn
@@ -1,0 +1,10 @@
+// Test: Nested object literals
+class EventEmitter {
+    $ emit(event: string, data: Any): void {
+        print("Emitting " + event + " with data: " + data);
+    }
+}
+
+emitter = EventEmitter();
+emitter.emit("user_event", {"user": {"name": "Bob", "profile": {"age": 30}}});
+emitter.emit("config_event", {"settings": {"debug": true, "features": {"auth": true}}});

--- a/tests/gh-15/variable_declarations_still_work.thorn
+++ b/tests/gh-15/variable_declarations_still_work.thorn
@@ -1,0 +1,8 @@
+// Test: Variable declarations with type annotations still work
+name: string = "Alice";
+age: number = 25;
+config: Any = {"debug": true};
+
+print("Name: " + name);
+print("Age: " + age);
+print("Config: " + config);


### PR DESCRIPTION
## Summary
- Fix critical parser bug where object literals in method calls caused "Expected ';' after variable declaration" errors
- Enhanced parser's colon lookahead logic to respect nesting levels and expression boundaries
- Updated large_event_system.thorn example to use object literals instead of wrapper classes

## Problem
Object literals in method calls and function arguments were incorrectly parsed as variable declarations:
- `obj.method({"key": "value"})` threw "Expected ';' after variable declaration" error
- `game_events.emit("event", {"time": "10:00 AM"})` failed to parse
- Required verbose class workarounds for simple data structures

## Root Cause
The `checkAhead(COLON)` method was too naive - it would find colons inside nested expressions and incorrectly assume they were part of variable type annotations like `name: string = value`.

## Solution
Enhanced `checkAhead(COLON)` method to:
1. **Track nesting levels** - ignore colons inside `{}`, `[]`, and `()` 
2. **Stop at expression boundaries** - don't look past operators like `.`, `(`, `[`
3. **Only consider top-level colons** - for actual variable declarations

## Code Changes
```java
// Before: Naive colon detection
private boolean checkAhead(TokenType type) {
    // Would find ANY colon ahead, even nested ones
}

// After: Nesting-aware colon detection
private boolean checkAhead(TokenType type) {
    // Tracks brace/paren/bracket depth
    // Only considers top-level colons
    // Stops at expression boundaries
}
```

## Test Results
- ✅ Object literals work in method calls: `obj.method({"key": "value"})`
- ✅ Object literals work in function arguments: `func({"config": "setting"})`
- ✅ Variable declarations still work: `name: string = "Alice"`
- ✅ Nested object literals work: `obj.method({"user": {"name": "Bob"}})`
- ✅ Both interpreter and VM modes support the fix
- ✅ No regressions in existing functionality

## Impact
This fix enables idiomatic object usage patterns:
- Event systems with data payloads
- Configuration objects
- Data structures without verbose classes
- Eliminates need for workaround wrapper classes

## Breaking Changes
None - this is a bug fix that enables expected functionality.

Fixes #15