### PR TITLE
gh-22: remove requirement for 'this.' in class property initialization

### DIFF
--- a/tests/gh-22/basic_property_init.thorn
+++ b/tests/gh-22/basic_property_init.thorn
@@ -1,0 +1,15 @@
+// Test basic property initialization without 'this.' prefix
+class BasicTest {
+    $ init() {
+        name: string = "Alice";
+        age: number = 25;
+        active: boolean = true;
+    }
+    
+    $ get_info() {
+        return this.name + " is " + this.age + " years old";
+    }
+}
+
+test = BasicTest();
+print(test.get_info());

--- a/tests/gh-22/constructor_only.thorn
+++ b/tests/gh-22/constructor_only.thorn
@@ -1,0 +1,22 @@
+// Test that the feature only works in constructor methods
+class ConstructorOnlyTest {
+    $ init() {
+        // This should work - creates properties
+        name: string = "Constructor";
+        value: number = 42;
+    }
+    
+    $ other_method() {
+        // This should create local variables, not properties
+        local_var: string = "local";
+        temp_num: number = 100;
+        
+        // Verify we can access the constructor-created properties
+        return this.name + " has value " + this.value + " and local " + local_var + " temp " + temp_num;
+    }
+}
+
+test = ConstructorOnlyTest();
+print("Name: " + test.name);
+print("Value: " + test.value);
+print("Method result: " + test.other_method());

--- a/tests/gh-22/mixed_initialization.thorn
+++ b/tests/gh-22/mixed_initialization.thorn
@@ -1,0 +1,24 @@
+// Test mixing new syntax with explicit this.property
+class MixedTest {
+    $ init() {
+        // New syntax
+        name: string = "Bob";
+        age: number = 30;
+        
+        // Explicit this.property (should still work)
+        this.explicit_prop = "explicit";
+        
+        // Without type hints
+        simple_value = "simple";
+    }
+    
+    $ show_all() {
+        print("name: " + this.name);
+        print("age: " + this.age);
+        print("explicit_prop: " + this.explicit_prop);
+        print("simple_value: " + this.simple_value);
+    }
+}
+
+test = MixedTest();
+test.show_all();


### PR DESCRIPTION
## Summary
- Implement clean property initialization syntax in class constructors
- Support both typed (`name: string = "value"`) and untyped (`name = "value"`) syntax
- Maintain backward compatibility with explicit `this.property` syntax
- Only apply transformation in constructor methods, not regular class methods

## Test plan
- [x] Basic property initialization with type hints
- [x] Mixed initialization (new syntax + explicit this.property)
- [x] Constructor-only behavior (regular methods use local variables)
- [x] Works in both tree-walking interpreter and bytecode VM modes