### PR TITLE
gh-14: add type hinting support for class instances

### DIFF
--- a/src/com/thorn/ThornInstance.java
+++ b/src/com/thorn/ThornInstance.java
@@ -26,6 +26,10 @@ class ThornInstance {
     void set(Token name, Object value) {
         fields.put(name.lexeme, value);
     }
+    
+    ThornClass getKlass() {
+        return klass;
+    }
 
     @Override
     public String toString() {

--- a/src/com/thorn/ThornType.java
+++ b/src/com/thorn/ThornType.java
@@ -226,11 +226,69 @@ class ThornArrayType extends ThornType {
 }
 
 /**
+ * Class type
+ */
+class ThornClassType extends ThornType {
+    private final String className;
+    
+    public ThornClassType(String className) {
+        this.className = className;
+    }
+    
+    @Override
+    public String getName() {
+        return className;
+    }
+    
+    @Override
+    public boolean matches(Object value) {
+        if (!(value instanceof ThornInstance)) return false;
+        ThornInstance instance = (ThornInstance) value;
+        return instance.getKlass().name.equals(className);
+    }
+    
+    @Override
+    public boolean isAssignableFrom(ThornType other) {
+        if (other instanceof ThornClassType) {
+            // For now, just check exact class match
+            // Future: support inheritance
+            return className.equals(((ThornClassType) other).className);
+        }
+        return false;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        ThornClassType that = (ThornClassType) obj;
+        return Objects.equals(className, that.className);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(className);
+    }
+}
+
+/**
  * Helper class for creating type instances
  */
 class ThornTypeFactory {
     public static ThornType createType(String name) {
-        return new ThornPrimitiveType(name);
+        // Check if this is a known primitive type
+        switch (name) {
+            case "string":
+            case "number":
+            case "boolean":
+            case "null":
+            case "Any":
+            case "void":
+                return new ThornPrimitiveType(name);
+            default:
+                // Assume it's a class type
+                return new ThornClassType(name);
+        }
     }
     
     public static ThornType createGenericType(String name, List<Object> typeArgs) {

--- a/tests/gh-14/arrays_of_classes.thorn
+++ b/tests/gh-14/arrays_of_classes.thorn
@@ -1,0 +1,37 @@
+// Test arrays of class instances
+
+class Person {
+    $ init(name: string, age: number) {
+        this.name = name;
+        this.age = age;
+    }
+    
+    $ info() {
+        return this.name + " (" + this.age + ")";
+    }
+}
+
+// Array of Person instances
+people: Array[Person] = [
+    Person("Alice", 25),
+    Person("Bob", 30),
+    Person("Charlie", 35)
+];
+
+// Function accepting array of Person
+$ print_people(persons: Array[Person]): void {
+    print("People in array:");
+    for (i = 0; i < persons.length; i = i + 1) {
+        print("  - " + persons[i].info());
+    }
+}
+
+// Test
+print_people(people);
+
+// Add more people
+people.push(Person("David", 40));
+people.push(Person("Eve", 28));
+
+print("\nAfter adding more:");
+print_people(people);

--- a/tests/gh-14/basic_class_type_hints.thorn
+++ b/tests/gh-14/basic_class_type_hints.thorn
@@ -1,0 +1,22 @@
+// Test basic class type hinting
+
+class Person {
+    $ init(name: string, age: number) {
+        this.name = name;
+        this.age = age;
+    }
+    
+    $ greet() {
+        return "Hello, I'm " + this.name;
+    }
+}
+
+// Type hinted class instances
+person1: Person = Person("Alice", 25);
+person2: Person = Person("Bob", 30);
+
+// Test that they work
+print(person1.greet());
+print(person2.greet());
+print("person1 age: " + person1.age);
+print("person2 age: " + person2.age);

--- a/tests/gh-14/function_with_class_types.thorn
+++ b/tests/gh-14/function_with_class_types.thorn
@@ -1,0 +1,30 @@
+// Test functions accepting and returning class instances
+
+class Person {
+    $ init(name: string, age: number) {
+        this.name = name;
+        this.age = age;
+    }
+    
+    $ greet() {
+        return "Hello, I'm " + this.name;
+    }
+}
+
+// Function accepting class instance
+$ process_person(p: Person): void {
+    print("Processing: " + p.name);
+    print("Age: " + p.age);
+}
+
+// Function returning class instance
+$ create_person(name: string, age: number): Person {
+    return Person(name, age);
+}
+
+// Test the functions
+alice: Person = Person("Alice", 25);
+process_person(alice);
+
+bob: Person = create_person("Bob", 30);
+print("Created: " + bob.greet());

--- a/tests/gh-14/mixed_types.thorn
+++ b/tests/gh-14/mixed_types.thorn
@@ -1,0 +1,43 @@
+// Test mixed primitive and class types
+
+class Employee {
+    $ init(name: string, department: string, salary: number) {
+        this.name = name;
+        this.department = department;
+        this.salary = salary;
+    }
+    
+    $ get_annual_bonus(): number {
+        return this.salary * 0.1;
+    }
+}
+
+// Variables with different types
+company_name: string = "TechCorp";
+employee_count: number = 150;
+is_public: boolean = true;
+ceo: Employee = Employee("Jane Smith", "Executive", 500000);
+
+// Function with mixed parameter types
+$ print_company_info(name: string, count: number, public: boolean, leader: Employee): void {
+    print("Company: " + name);
+    print("Employees: " + count);
+    print("Public: " + public);
+    print("CEO: " + leader.name + " (Annual bonus: $" + leader.get_annual_bonus() + ")");
+}
+
+// Test
+print_company_info(company_name, employee_count, is_public, ceo);
+
+// Collections with mixed content
+employees: Array[Employee] = [
+    Employee("Alice", "Engineering", 120000),
+    Employee("Bob", "Sales", 90000),
+    ceo
+];
+
+print("\nAll employees:");
+for (i = 0; i < employees.length; i = i + 1) {
+    emp: Employee = employees[i];
+    print("  " + emp.name + " - " + emp.department);
+}


### PR DESCRIPTION
## Summary
- Implement type hinting for class instances (e.g., `person: Person = Person("Alice", 25)`)
- Add new `ThornClassType` to properly validate class instance assignments
- Support class types in function parameters and return types
- Enable `Array[ClassName]` syntax for collections of class instances

## Implementation Details
- Created `ThornClassType` class that checks if values are instances of the specified class
- Modified `ThornTypeFactory` to detect primitive types vs class types
- Added `getKlass()` method to `ThornInstance` for type checking
- Parser already supported identifier types, so no parser changes needed
- Works in both tree-walking interpreter and bytecode VM

## Test Plan
- [x] Basic class instance type hints
- [x] Functions accepting and returning class instances
- [x] Arrays of class instances with proper type checking
- [x] Mixed primitive and class types
- [x] All tests pass in both interpreter and VM modes

## Future Enhancements
- Support for inheritance checking (subclass compatibility)
- Optional/nullable class types (e.g., `Person?`)
- Interface/protocol support